### PR TITLE
Add HtlcInfo contructor and hash type constants

### DIFF
--- a/lib/src/embedded/constants.dart
+++ b/lib/src/embedded/constants.dart
@@ -58,3 +58,5 @@ const int sporkDescriptionMaxLength = 400;
 const int htlcPreimageMinLength = 1;
 const int htlcPreimageMaxLength = 255;
 const int htlcPreimageDefaultLength = 32;
+const int htlcHashTypeSha3 = 0;
+const int htlcHashTypeSha256 = 1;

--- a/lib/src/model/embedded/htlc.dart
+++ b/lib/src/model/embedded/htlc.dart
@@ -10,7 +10,18 @@ class HtlcInfo {
   int expirationTime;
   int hashType;
   int keyMaxSize;
-  List<int>? hashLock;
+  List<int> hashLock;
+
+  HtlcInfo(
+      {required this.id,
+      required this.timeLocked,
+      required this.hashLocked,
+      required this.tokenStandard,
+      required this.amount,
+      required this.expirationTime,
+      required this.hashType,
+      required this.keyMaxSize,
+      required this.hashLock});
 
   HtlcInfo.fromJson(Map<String, dynamic> json)
       : id = Hash.parse(json['id']),

--- a/lib/src/model/embedded/htlc.dart
+++ b/lib/src/model/embedded/htlc.dart
@@ -1,5 +1,5 @@
 import 'package:znn_sdk_dart/src/model/primitives.dart';
-import 'dart:convert';
+import 'package:znn_sdk_dart/src/utils/utils.dart';
 
 class HtlcInfo {
   Hash id;
@@ -32,17 +32,17 @@ class HtlcInfo {
         expirationTime = json['expirationTime'],
         hashType = json['hashType'],
         keyMaxSize = json['keyMaxSize'],
-        hashLock = base64.decode(json['hashLock']);
+        hashLock = BytesUtils.base64ToBytes(json['hashLock']) ?? [];
 
   Map<String, dynamic> toJson() => {
-        'id': id,
-        'timeLocked': timeLocked,
-        'hashLocked': hashLocked,
-        'tokenStandard': tokenStandard,
+        'id': id.toString(),
+        'timeLocked': timeLocked.toString(),
+        'hashLocked': hashLocked.toString(),
+        'tokenStandard': tokenStandard.toString(),
         'amount': amount,
         'expirationTime': expirationTime,
         'hashType': hashType,
         'keyMaxSize': keyMaxSize,
-        'hashLock': hashLock
+        'hashLock': BytesUtils.bytesToBase64(hashLock)
       };
 }


### PR DESCRIPTION
The changes made in this PR are as follows:

- Constants have been added for HTLC hash types.
- A constructor for the `HtlcInfo` model has been added so that clients can construct the model.
- The `HtlcInfo` model's `toJson()` method has been updated to convert the values into json compatible types.
- The `HtlcInfo` model has been updated to use the SDK's `BytesUtils` for base64 conversions.
- The `HtlcInfo` model's `hashLock` property was changed to be non-nullable.